### PR TITLE
JSON-RPC client module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 JSON-RPC 2.0 for Erlang
 =======================
 
-This is a JSON-RPC 2.0 request handler.
+Transport agnostic library for JSON-RPC 2.0 servers and clients.
+
+This page contains the manual for the server part, the `jsonrpc2` module. The client part has a
+separate module `jsonrpc2_client`. Client docs are yet to be written. For documentation on the
+client library, see the source code: [jsonrpc2_client.erl](src/jsonrpc2_client.erl).
 
 Features
 --------

--- a/src/jsonrpc2.erl
+++ b/src/jsonrpc2.erl
@@ -19,6 +19,7 @@
 -type id() :: number() | null.
 -type errortype() :: parse_error | method_not_found | invalid_params |
                      internal_error | server_error.
+-type error() :: errortype() | {errortype(), json()}.
 -type request() :: {method(), params(), id() | undefined} | invalid_request.
 -type response() :: {reply, json()} | noreply.
 
@@ -26,7 +27,7 @@
 -type mapfun() :: fun((fun((A) -> B), [A]) -> [B]). % should be the same as lists:map/2
 
 -export_type([json/0, method/0, params/0, id/0, handlerfun/0, mapfun/0,
-              response/0, errortype/0]).
+              response/0, errortype/0, error/0]).
 
 %% @doc Handles a raw JSON-RPC request, using the supplied JSON decode and
 %% encode functions.


### PR DESCRIPTION
Includes some changes in the server module (jsonrpc2), e.g. exporting some types that we need in the client module.
