### PR TITLE
Add stacktrace to internal error message

### DIFF
--- a/src/jsonrpc2.erl
+++ b/src/jsonrpc2.erl
@@ -198,8 +198,8 @@ dispatch({Method, Params, Id}, HandlerFun) ->
             make_error_response(Code, Message, Data, Id);
         Class:Error ->
             error_logger:error_msg(
-                "Error in JSON-RPC handler for method ~s with params ~p: ~p:~p",
-                [Method, Params, Class, Error]),
+                "Error in JSON-RPC handler for method ~s with params ~p: ~p:~p from ~p",
+                [Method, Params, Class, Error, erlang:get_stacktrace()]),
             make_standard_error_response(internal_error, Id)
     end;
 dispatch(_, _HandlerFun) ->


### PR DESCRIPTION
Thank you for your work. I think it is better to log stacktrace. Sometimes it is very important
